### PR TITLE
Change damage base patches to limb

### DIFF
--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -91,7 +91,7 @@ namespace GTFuckingXP
 
             //General xp mod usage
             Harmony.PatchAll(typeof(GS_InLevelPatches));
-            Harmony.PatchAll(typeof(EnemyDamageBasePatches));
+            Harmony.PatchAll(typeof(EnemyDamageLimbPatches));
             Harmony.PatchAll(typeof(GS_AfterLevelPatches));
             Harmony.PatchAll(typeof(PlaceNavMarkerOnGoPatches));
             Harmony.PatchAll(typeof(SnetSessionHubPatches));

--- a/GTF_Xp/Patches/EnemyDamageLimbPatches.cs
+++ b/GTF_Xp/Patches/EnemyDamageLimbPatches.cs
@@ -6,13 +6,13 @@ using HarmonyLib;
 
 namespace GTFuckingXp.Patches
 {
-    [HarmonyPatch(typeof(Dam_EnemyDamageBase))]
-    public static class EnemyDamageBasePatches
+    [HarmonyPatch(typeof(Dam_EnemyDamageLimb))]
+    public static class EnemyDamageLimbPatches
     {
 
-        [HarmonyPatch(nameof(Dam_EnemyDamageBase.MeleeDamage))]
+        [HarmonyPatch(nameof(Dam_EnemyDamageLimb.MeleeDamage))]
         [HarmonyPrefix]
-        public static void MeleePrefix(Dam_EnemyDamageBase __instance, ref float dam, Agent sourceAgent)
+        public static void MeleePrefix(Dam_EnemyDamageLimb __instance, ref float dam, Agent sourceAgent)
         {
             if (!__instance.Owner.Alive)
                 return;
@@ -30,10 +30,9 @@ namespace GTFuckingXp.Patches
             }
         }
 
-        [HarmonyBefore(BepInExLoader.GUID, "com.dak.DamageNumbers")]
-        [HarmonyPatch(nameof(Dam_EnemyDamageBase.BulletDamage))]
+        [HarmonyPatch(nameof(Dam_EnemyDamageLimb.BulletDamage))]
         [HarmonyPrefix]
-        public static void BulletPostfix(Dam_EnemyDamageBase __instance, ref float dam, Agent sourceAgent)
+        public static void BulletPostfix(Dam_EnemyDamageLimb __instance, ref float dam, Agent sourceAgent)
         {
             if (!__instance.Owner.Alive)
                 return;


### PR DESCRIPTION
Fixes hitmarkers not utilizing level damage scalars. No longer needs priority annotation since limb function runs before base function.