### PR TITLE
v2.2.1

### DIFF
--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -26,7 +26,7 @@ namespace GTFuckingXP
         MODNAME = "GTFuckingXP",
         AUTHOR = "Endskill",
         GUID = AUTHOR + "." + MODNAME,
-        VERSION = "2.2.0";
+        VERSION = "2.2.1";
 
         public static bool RundownDevMode { get; private set; }
         public static ConfigEntry<bool> DebugMessages { get; private set; }

--- a/GTF_Xp/Extensions/Information/Level/Json/CustomBuffConverter.cs
+++ b/GTF_Xp/Extensions/Information/Level/Json/CustomBuffConverter.cs
@@ -41,7 +41,10 @@ namespace GTFuckingXP.Extensions.Information.Level.Json
                     switch (propertyName)
                     {
                         case nameof(CustomScalingBuff.CustomBuff):
-                            buff.CustomBuff = reader.GetString().ToEnum(CustomScaling.Invalid);
+                            if (reader.TokenType == JsonTokenType.String)
+                                buff.CustomBuff = reader.GetString().ToEnum(CustomScaling.Invalid);
+                            else
+                                buff.CustomBuff = (CustomScaling) reader.GetInt32();
                             break;
                         case nameof(CustomScalingBuff.Value):
                             buff.Value = reader.GetSingle();

--- a/GTF_Xp/Extensions/Information/Level/Json/SingleBuffConverter.cs
+++ b/GTF_Xp/Extensions/Information/Level/Json/SingleBuffConverter.cs
@@ -41,7 +41,10 @@ namespace GTFuckingXP.Extensions.Information.Level.Json
                     switch (propertyName)
                     {
                         case nameof(SingleUseBuff.SingleBuff):
-                            buff.SingleBuff = reader.GetString().ToEnum(SingleBuff.Invalid);
+                            if (reader.TokenType == JsonTokenType.String)
+                                buff.SingleBuff = reader.GetString().ToEnum(SingleBuff.Invalid);
+                            else
+                                buff.SingleBuff = (SingleBuff)reader.GetInt32();
                             break;
                         case nameof(SingleUseBuff.Value):
                             buff.Value = reader.GetSingle();


### PR DESCRIPTION
Small fix to the converters. Allows them to accept Enum integer values, which fixes networked buffs not being read (they get sent as ints). Confirmed working with a client.