### PR TITLE
v2.3.1 + v2.3.2

### DIFF
--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -21,6 +21,7 @@ namespace GTFuckingXP
     [BepInDependency("Endskill.EndskApi", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("com.dak.FloatingTextAPI", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency(ESCWrapper.PLUGIN_GUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency(CCWrapper.PLUGIN_GUID, BepInDependency.DependencyFlags.SoftDependency)]
     public class BepInExLoader : BasePlugin
     {
         public const string
@@ -100,6 +101,8 @@ namespace GTFuckingXP
             Harmony.PatchAll(typeof(GS_AfterLevelPatches));
             Harmony.PatchAll(typeof(PlaceNavMarkerOnGoPatches));
             Harmony.PatchAll(typeof(SnetSessionHubPatches));
+            if (!CCWrapper.HasCC) // CConsole native patches the function we need, can't patch if it exists
+                Harmony.PatchAll(typeof(PlayerRegenPatches));
         }
 
         private void TermsOfUsageChanged(object sender, EventArgs e)

--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -27,7 +27,7 @@ namespace GTFuckingXP
         MODNAME = "GTFuckingXP",
         AUTHOR = "Endskill",
         GUID = AUTHOR + "." + MODNAME,
-        VERSION = "2.3.0";
+        VERSION = "2.3.1";
 
         public static bool RundownDevMode { get; private set; }
         public static ConfigEntry<bool> DebugMessages { get; private set; }

--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -20,6 +20,7 @@ namespace GTFuckingXP
     [BepInDependency("dev.gtfomodding.gtfo-api", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("Endskill.EndskApi", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("com.dak.FloatingTextAPI", BepInDependency.DependencyFlags.HardDependency)]
+    [BepInDependency(ESCWrapper.PLUGIN_GUID, BepInDependency.DependencyFlags.SoftDependency)]
     public class BepInExLoader : BasePlugin
     {
         public const string
@@ -69,6 +70,7 @@ namespace GTFuckingXP
             BoosterBuffManager.Instance = new BoosterBuffManager();
 
             NetworkApiXpManager.Setup();
+            ESCWrapper.Init();
 
             Harmony = new Harmony(GUID);
             FasterPatching();

--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -28,7 +28,7 @@ namespace GTFuckingXP
         MODNAME = "GTFuckingXP",
         AUTHOR = "Endskill",
         GUID = AUTHOR + "." + MODNAME,
-        VERSION = "2.3.1";
+        VERSION = "2.3.2";
 
         public static bool RundownDevMode { get; private set; }
         public static ConfigEntry<bool> DebugMessages { get; private set; }

--- a/GTF_Xp/Extensions/CCWrapper.cs
+++ b/GTF_Xp/Extensions/CCWrapper.cs
@@ -1,0 +1,15 @@
+﻿using BepInEx.Unity.IL2CPP;
+
+namespace GTFuckingXP.Extensions
+{
+    internal static class CCWrapper
+    {
+        public const string PLUGIN_GUID = "CConsole";
+        public static readonly bool HasCC;
+
+        static CCWrapper()
+        {
+            HasCC = IL2CPPChainloader.Instance.Plugins.ContainsKey(PLUGIN_GUID);
+        }
+    }
+}

--- a/GTF_Xp/Extensions/ESCWrapper.cs
+++ b/GTF_Xp/Extensions/ESCWrapper.cs
@@ -24,12 +24,10 @@ namespace GTFuckingXP.Extensions
         private static void AddRefreshCallbackESC() => MovementMultiplierManager.AddRefreshCallback(OnRefresh);
         private static float OnRefresh() => CacheApiWrapper.GetActiveLevel().CustomScaling.FirstOrDefault(buff => buff.CustomBuff == Enums.CustomScaling.MovementSpeedMultiplier)?.Value ?? 1f;
 
-        public static bool RefreshMovementSpeed()
+        public static void RefreshMovementSpeed()
         {
-            if (!HasESC) return false;
-
-            RefreshMovementSpeedESC();
-            return true;
+            if (HasESC)
+                RefreshMovementSpeedESC();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/GTF_Xp/Extensions/ESCWrapper.cs
+++ b/GTF_Xp/Extensions/ESCWrapper.cs
@@ -1,0 +1,38 @@
+﻿using BepInEx.Unity.IL2CPP;
+using ExtraSyringeCustomization.Utils;
+using System.Runtime.CompilerServices;
+
+namespace GTFuckingXP.Extensions
+{
+    internal class ESCWrapper
+    {
+        public const string PLUGIN_GUID = "dev.flaff.gtfo.ExtraSyringeCustomization";
+        public static bool HasESC { get; }
+
+        static ESCWrapper()
+        {
+            HasESC = IL2CPPChainloader.Instance.Plugins.ContainsKey(PLUGIN_GUID);
+        }
+
+        public static void Init()
+        {
+            if (HasESC)
+                AddRefreshCallbackESC();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void AddRefreshCallbackESC() => MovementMultiplierManager.AddRefreshCallback(OnRefresh);
+        private static float OnRefresh() => CacheApiWrapper.GetActiveLevel().CustomScaling.FirstOrDefault(buff => buff.CustomBuff == Enums.CustomScaling.MovementSpeedMultiplier)?.Value ?? 1f;
+
+        public static bool RefreshMovementSpeed()
+        {
+            if (!HasESC) return false;
+
+            RefreshMovementSpeedESC();
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void RefreshMovementSpeedESC() => MovementMultiplierManager.Refresh();
+    }
+}

--- a/GTF_Xp/Managers/CustomScalingBuffManager.cs
+++ b/GTF_Xp/Managers/CustomScalingBuffManager.cs
@@ -138,16 +138,6 @@ namespace GTFuckingXP.Managers
 
                     playerData.jumpVerticalVelocityMax = jumpVelocityMax + value;
                     break;
-                case CustomScaling.RegenStartDelayMultiplier:
-                    if (!CacheApiWrapper.TryGetDefaultCustomScaling(customBuff, out float regenDelay))
-                    {
-                        regenDelay = playerData.healthRegenStartDelayAfterDamage;
-                        CacheApiWrapper.SetDefaultCustomScaling(customBuff, regenDelay);
-                    }
-
-                    playerData.healthRegenStartDelayAfterDamage = regenDelay * value;
-                    targetAgent.Damage.m_nextRegen = Math.Min(targetAgent.Damage.m_nextRegen, Clock.Time + regenDelay * value);
-                    break;
                 case CustomScaling.AmmoEfficiency:
                     // Not how defaults are used elsewhere, but has better compatibility with EWC
                     if (!CacheApiWrapper.TryGetDefaultCustomScaling(customBuff, out float lastAmmo))

--- a/GTF_Xp/Managers/CustomScalingBuffManager.cs
+++ b/GTF_Xp/Managers/CustomScalingBuffManager.cs
@@ -62,19 +62,25 @@ namespace GTFuckingXP.Managers
                     meleeData.AttackSphereRadius = meleeHitbox * value;
                     break;
                 case CustomScaling.MovementSpeedMultiplier:
-                    if (!CacheApiWrapper.TryGetDefaultCustomScaling(customBuff, out (float walk, float run, float air, float crouch) movementInfo))
+                    if (ESCWrapper.HasESC)
+                    {
+                        ESCWrapper.RefreshMovementSpeed();
+                        break;
+                    }
+
+                    if (!CacheApiWrapper.TryGetDefaultCustomScaling(customBuff, out (float walk, float run, float crouch, float air) movementInfo))
                     {
                         movementInfo.walk = playerData.walkMoveSpeed;
                         movementInfo.run = playerData.runMoveSpeed;
-                        movementInfo.air = playerData.airMoveSpeed;
                         movementInfo.crouch = playerData.crouchMoveSpeed;
+                        movementInfo.air = playerData.airMoveSpeed;
                         CacheApiWrapper.SetDefaultCustomScaling(customBuff, movementInfo);
                     }
 
                     playerData.walkMoveSpeed = movementInfo.walk * value;
                     playerData.runMoveSpeed = movementInfo.run * value;
-                    playerData.airMoveSpeed = movementInfo.air * value;
                     playerData.crouchMoveSpeed = movementInfo.crouch * value;
+                    playerData.airMoveSpeed = movementInfo.air * value;
                     break;
                 //case CustomScaling.AntiFogSphere:
                 //    break;

--- a/GTF_Xp/Patches/PlayerDamagePatches.cs
+++ b/GTF_Xp/Patches/PlayerDamagePatches.cs
@@ -11,12 +11,14 @@ namespace GTFuckingXp.Patches
     internal static class PlayerDamagePatches
     {
         // Dam_PlayerDamageBase does not override FireDamage
-        // Assuming that only players will be damaged by this since it's unused in other mods/vanilla AFAIK
         [HarmonyPatch(nameof(Dam_SyncedDamageBase.FireDamage))]
         [HarmonyPrefix]
-        private static void Prefix_FireDamage(ref float dam, Agent sourceAgent)
+        private static void Prefix_FireDamage(Dam_SyncedDamageBase __instance, ref float dam, Agent sourceAgent)
         {
-            if (sourceAgent == null || !sourceAgent.Alive || !sourceAgent.IsLocallyOwned || sourceAgent.Type != AgentType.Player) return;
+            if (__instance.DamageBaseOwner != DamageBaseOwnerType.Player) return;
+            PlayerAgent player = __instance.GetBaseAgent().Cast<PlayerAgent>();
+
+            if (!player.Alive || !player.IsLocallyOwned) return;
 
             CustomScalingBuff? buff = CacheApiWrapper.GetActiveLevel().CustomScaling.FirstOrDefault(buff => buff.CustomBuff == CustomScaling.BleedResistance);
             if (buff != null)

--- a/GTF_Xp/Patches/PlayerRegenPatches.cs
+++ b/GTF_Xp/Patches/PlayerRegenPatches.cs
@@ -1,0 +1,28 @@
+﻿using GTFuckingXP.Extensions;
+using HarmonyLib;
+using GTFuckingXP.Information.Level;
+using GTFuckingXP.Enums;
+using Player;
+
+namespace GTFuckingXp.Patches
+{
+    [HarmonyPatch(typeof(Dam_PlayerDamageBase))]
+    internal static class PlayerRegenPatches
+    {
+        [HarmonyPatch(nameof(Dam_PlayerDamageBase.OnIncomingDamage))]
+        [HarmonyPostfix]
+        private static void Postfix_OnDamage(Dam_PlayerDamageBase __instance)
+        {
+            PlayerAgent player = __instance.Owner;
+            Level? level;
+            if (player.IsLocallyOwned)
+                level = CacheApiWrapper.GetActiveLevel();
+            else if (!CacheApiWrapper.GetPlayerToLevelMapping().TryGetValue(player.PlayerSlotIndex, out level))
+                return;
+
+            CustomScalingBuff? buff = level.CustomScaling.FirstOrDefault(buff => buff.CustomBuff == CustomScaling.RegenStartDelayMultiplier);
+            if (buff != null)
+                __instance.m_nextRegen = Clock.Time + player.PlayerData.healthRegenStartDelayAfterDamage * buff.Value;
+        }
+    }
+}


### PR DESCRIPTION
Fixes incompatibility issues with ExtraSyringeCustomization speed changes (overrides speed changes on level up).
Also restricts fire (bleed) damage to players just in case other plugins need to use it for enemies (AFAIK nothing does currently).

Also I couldn't be bothered to figure out how Expansions is formatted or done so I just stuck it under Xp/Extensions, lmk if you want it somewhere else

Edit: v2.3.2 added in same PR cuz I forgor how github works. Fixes the RegenStartDelayMultiplier not functioning correctly. Previously it updated for the local player, but this value is only used by host, so all players were tied to the host's multiplier. This modifies it to apply separately for each player (CConsole-incompatible since it native patches the function we need). Also fixes friendly fire not being modified by WeaponDamageMultiplier.