### PR TITLE
v2.3.3

### DIFF
--- a/GTF_Xp/BepInExLoader.cs
+++ b/GTF_Xp/BepInExLoader.cs
@@ -28,13 +28,15 @@ namespace GTFuckingXP
         MODNAME = "GTFuckingXP",
         AUTHOR = "Endskill",
         GUID = AUTHOR + "." + MODNAME,
-        VERSION = "2.3.2";
+        VERSION = "2.3.3";
 
         public static bool RundownDevMode { get; private set; }
         public static ConfigEntry<bool> DebugMessages { get; private set; }
         public static ConfigEntry<bool> LvlUpPopups { get; private set; }
         public static ConfigEntry<bool> XpPopups { get; private set; }
         public static ConfigEntry<string> TermsOfUsage { get; internal set; }
+        public static ConfigEntry<bool> ShowPlayerLevels { get; private set; }
+        public static ConfigEntry<string> LevelColor { get; internal set; }
         public static TermsOfUsage TermsOfUsageState { get; private set; }
         public static Harmony Harmony { get; private set; }
 
@@ -45,6 +47,9 @@ namespace GTFuckingXP
             
             LvlUpPopups = Config.Bind("Popups", "Lvl up popups", true, "If Lvl UP popups should be shown.");
             XpPopups = Config.Bind("Popups", "XP gain popups", true, "If XP gain popups should be shown");
+
+            ShowPlayerLevels = Config.Bind("Player Level Text", "Show Player Levels", true, "If levels should be shown above other players' names.");
+            LevelColor = Config.Bind("Player Level Text", "Level Text Color", "F80", "The color used for player levels.");
 
             //TODO remove
             TermsOfUsageState = Information.TermsOfUsage.Declined;
@@ -99,7 +104,8 @@ namespace GTFuckingXP
             Harmony.PatchAll(typeof(SentryGunCheckPatches));
             Harmony.PatchAll(typeof(SentryGunFiringPatches));
             Harmony.PatchAll(typeof(GS_AfterLevelPatches));
-            Harmony.PatchAll(typeof(PlaceNavMarkerOnGoPatches));
+            if (ShowPlayerLevels.Value)
+                Harmony.PatchAll(typeof(PlaceNavMarkerOnGoPatches));
             Harmony.PatchAll(typeof(SnetSessionHubPatches));
             if (!CCWrapper.HasCC) // CConsole native patches the function we need, can't patch if it exists
                 Harmony.PatchAll(typeof(PlayerRegenPatches));

--- a/GTF_Xp/Managers/CustomScalingBuffManager.cs
+++ b/GTF_Xp/Managers/CustomScalingBuffManager.cs
@@ -169,6 +169,8 @@ namespace GTFuckingXP.Managers
             foreach (CustomScaling customBuff in Enum.GetValues(typeof(CustomScaling)))
                 if (CacheApiWrapper.HasDefaultCustomScaling(customBuff))
                     SetCustomBuff(customBuff, GetResetModifier(customBuff), targetAgent);
+
+            ESCWrapper.RefreshMovementSpeed(); // Has no default but we need this to be refreshed on level drop
         }
 
         public static void ClearDefaultCustomBuffs()

--- a/GTF_Xp/Managers/ScriptManager.cs
+++ b/GTF_Xp/Managers/ScriptManager.cs
@@ -1,4 +1,5 @@
-﻿using EndskApi.Api;
+﻿using BepInEx.Unity.IL2CPP.Utils.Collections;
+using EndskApi.Api;
 using GameData;
 using GTFuckingXp.Information;
 using GTFuckingXp.Managers;
@@ -108,6 +109,19 @@ namespace GTFuckingXP.Managers
         /// </summary>  
         public void StartLevelScripts()
         {
+            CoroutineManager.StartCoroutine(StartWhenPlayerExists().WrapToIl2Cpp());
+
+            //if (BepInExLoader.RundownDevMode)
+            //{
+            //    CacheApiWrapper.DestroyOldCreateRegisterAndReturnComponent<DevModeTools>();
+            //}
+        }
+
+        private System.Collections.IEnumerator StartWhenPlayerExists()
+        {
+            while (!PlayerManager.HasLocalPlayerAgent())
+                yield return null;
+
             CacheApi.SaveInstance(GuiManager.Current.m_playerLayer.m_playerStatus.gameObject.AddComponent<XpBar>(), CacheApiWrapper.XpModCacheName);
             _ = CacheApiWrapper.DestroyOldCreateRegisterAndReturnComponent<XpHandler>();
 
@@ -116,11 +130,6 @@ namespace GTFuckingXP.Managers
                 //i don't think, anyone other than the XpExpansion mod will use that functionality, so let's just go quering it each loopitem.
                 callBack.Invoke(CacheApiWrapper.GetActiveLevel());
             }
-
-            //if (BepInExLoader.RundownDevMode)
-            //{
-            //    CacheApiWrapper.DestroyOldCreateRegisterAndReturnComponent<DevModeTools>();
-            //}
         }
 
         /// <summary>
@@ -128,14 +137,13 @@ namespace GTFuckingXP.Managers
         /// </summary>
         public void EndLevelScripts()
         {
-            CustomScalingBuffManager.ResetCustomBuffs(PlayerManager.GetLocalPlayerAgent());
-            CustomScalingBuffManager.ClearDefaultCustomBuffs();
-
             CacheApi.GetInstance<XpBar>(CacheApiWrapper.XpModCacheName).HideTextUi();
             CacheApiWrapper.KillScript<XpHandler>();
             CacheApiWrapper.KillScript<XpBar>();
             CacheApiWrapper.KillScript<DevModeTools>();
             CacheApiWrapper.SetPlayerToLevelMapping(new Dictionary<int, Level>());
+            CustomScalingBuffManager.ResetCustomBuffs(PlayerManager.GetLocalPlayerAgent());
+            CustomScalingBuffManager.ClearDefaultCustomBuffs();
         }
 
         public (List<EnemyXp> enemyXpList, List<LevelLayout> levelLayouts, List<BoosterBuffs> boosterBuffs, List<Group> groups) ReadJsonBlocks()

--- a/GTF_Xp/Patches/PlaceNavMarkerOnGoPatches.cs
+++ b/GTF_Xp/Patches/PlaceNavMarkerOnGoPatches.cs
@@ -13,7 +13,7 @@ namespace GTFuckingXP.Patches
             var playerToLevelMap = CacheApiWrapper.GetPlayerToLevelMapping();
             if (playerToLevelMap.TryGetValue(__instance.m_player.PlayerSlotIndex, out var levelNumber))
             {
-                name = $"<color=#F80>Lv.{levelNumber.LevelNumber}</color> {name}";
+                name = $"<color=#{BepInExLoader.LevelColor.Value}>Lv.{levelNumber.LevelNumber}</color> {name}";
             }
         }
     }


### PR DESCRIPTION
Fixes speed not being included among reset fields when ESC is also installed.
Fixes XpHandler failing to initialize on JIP since the PlayerAgent is not created when LevelStart is called. Fix is very hacky but I'm too lazy to do a proper one.
Adds some config settings for the level text shown above other players' names, at the request of a user.